### PR TITLE
Landing page links

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@
   gtag('config', 'UA-169665333-3');
 </script>
 </head>
-<body>
+<body style="margin:0px;">
 <div align="center">
     <a href="https://github.com/EESSI"><img src="./img/EESSI_logo_horizontal.png"/></a>
-    <p><em>(click to continue)</em></p>
-</div>
+    <p style="margin:0px;"><a href="https://github.com/EESSI">github.com/EESSI</a></p>
+    <p><a href="https://eessi.github.io/docs/">documentation</a></p></div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,8 +14,12 @@
 <body style="margin:0px;">
 <div align="center">
     <a href="https://github.com/EESSI"><img src="./img/EESSI_logo_horizontal.png"/></a>
-    <p style="margin:0px;"><a href="https://github.com/EESSI">github.com/EESSI</a></p>
-    <p><a href="https://eessi.github.io/docs/">documentation</a></p>
+    <p style="margin:0px;">
+      <a href="https://eessi-hpc.org">eessi-hpc.org</a> - 
+      <a href="https://github.com/EESSI">github.com/EESSI</a> - 
+      <a href="https://eessi.github.io/docs/">eessi.github.io/docs</a> - 
+      <a href="https://twitter.com/eessi_hpc">twitter.com/eessi_hpc</a>
+    </p>
 </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 <div align="center">
     <a href="https://github.com/EESSI"><img src="./img/EESSI_logo_horizontal.png"/></a>
     <p style="margin:0px;"><a href="https://github.com/EESSI">github.com/EESSI</a></p>
-    <p><a href="https://eessi.github.io/docs/">documentation</a></p></div>
+    <p><a href="https://eessi.github.io/docs/">documentation</a></p>
+</div>
 </body>
 </html>


### PR DESCRIPTION
Replaced "(click to continue)" with links to github and documentation.
Removed some vertical white space.