### PR TITLE
replace link to join EESSI Slack

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <div align="center">
     <a href="https://github.com/EESSI"><img src="./img/EESSI_logo_horizontal.png" width="800"/></a><br/>
     <p class="eessi_links">
-      <a href="https://join.slack.com/t/eessi-hpc/shared_invite/zt-1wqy0t8g6-PZJTg3Hjjm5Fm3XEOkzECg">Slack channel</a>
+      <a href="https://join.slack.com/t/eessi-hpc/shared_invite/zt-2wg10p26d-m_CnRB89xQq3zk9qxf1k3g">Slack channel</a>
       &nbsp;&nbsp;|&nbsp;&nbsp;
       <a href="https://eessi.io/docs/">Documentation</a>
       &nbsp;&nbsp;|&nbsp;&nbsp;


### PR DESCRIPTION
Current link was reported not to work, led to "`There's been a glitch...`" error, so replacing it...